### PR TITLE
Apply blue theme to settings pages interactive components

### DIFF
--- a/client/global.css
+++ b/client/global.css
@@ -123,4 +123,11 @@
   [data-radix-portal] {
     contain: layout;
   }
+
+  /* Settings pages: force primary to blue */
+  .settings-blue-theme {
+    --primary: 221.2 83.2% 53.3%; /* Tailwind blue-600 */
+    --primary-foreground: 210 40% 98%;
+    --ring: 221.2 83.2% 53.3%;
+  }
 }

--- a/client/pages/settings/Appearance.tsx
+++ b/client/pages/settings/Appearance.tsx
@@ -79,7 +79,7 @@ const Appearance: React.FC = () => {
   const scheme = COLOR_PRESETS[colorScheme];
 
   return (
-    <div className="space-y-6">
+    <div className="settings-blue-theme space-y-6">
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="theme">Theme & Color</TabsTrigger>

--- a/client/pages/settings/LanguageTimezone.tsx
+++ b/client/pages/settings/LanguageTimezone.tsx
@@ -23,7 +23,7 @@ import { Globe, Clock, Calendar, Languages } from "lucide-react";
 
 const LanguageTimezone: React.FC = () => {
   return (
-    <div className="space-y-6">
+    <div className="settings-blue-theme space-y-6">
       <Tabs defaultValue="language" className="space-y-6">
         <TabsList className="grid w-full grid-cols-4">
           <TabsTrigger value="language">Language</TabsTrigger>

--- a/client/pages/settings/Notifications.tsx
+++ b/client/pages/settings/Notifications.tsx
@@ -210,7 +210,7 @@ const Notifications: React.FC = () => {
     setEnabled((p) => ({ ...p, [id]: value }));
 
   return (
-    <div className="space-y-6">
+    <div className="settings-blue-theme space-y-6">
       {/* General Notifications with multi-channel selection */}
       <Card>
         <CardHeader>

--- a/client/pages/settings/SystemIntegration.tsx
+++ b/client/pages/settings/SystemIntegration.tsx
@@ -91,7 +91,7 @@ const SystemIntegration: React.FC = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="settings-blue-theme space-y-6">
       <Tabs defaultValue="overview" className="space-y-6">
         <TabsList className="grid w-full grid-cols-5">
           <TabsTrigger value="overview">Overview</TabsTrigger>

--- a/client/pages/settings/SystemParameters.tsx
+++ b/client/pages/settings/SystemParameters.tsx
@@ -36,7 +36,7 @@ const SystemParameters: React.FC = () => {
   const [auditRetention, setAuditRetention] = React.useState([90]);
 
   return (
-    <div className="space-y-6">
+    <div className="settings-blue-theme space-y-6">
       <Tabs defaultValue="security" className="space-y-6">
         <TabsList className="grid w-full grid-cols-6">
           <TabsTrigger value="security">Security</TabsTrigger>


### PR DESCRIPTION
## Purpose

Update the visual appearance of interactive components in the settings pages to use a consistent blue color scheme. This change ensures that primary action buttons, slider controls, and switch controls across all settings pages have a unified blue appearance for better visual consistency.

## Code changes

- Added new CSS class `settings-blue-theme` in `global.css` that overrides primary color variables to use Tailwind blue-600
- Applied the `settings-blue-theme` class to the root container of all settings pages:
  - Appearance.tsx
  - LanguageTimezone.tsx  
  - Notifications.tsx
  - SystemIntegration.tsx
  - SystemParameters.tsx

The theme override sets primary colors to blue (#3B82F6) with appropriate foreground and ring colors for optimal contrast and accessibility.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1f79b8264cce4e1ca34f561f781562ad/spark-hub)

👀 [Preview Link](https://1f79b8264cce4e1ca34f561f781562ad-spark-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1f79b8264cce4e1ca34f561f781562ad</projectId>-->
<!--<branchName>spark-hub</branchName>-->